### PR TITLE
Fix serialization of null public keys

### DIFF
--- a/lib/ecc/src/PublicKey.js
+++ b/lib/ecc/src/PublicKey.js
@@ -19,10 +19,14 @@ class PublicKey {
     }
 
     static fromBuffer(buffer) {
+        if (buffer.toString('hex') === '000000000000000000000000000000000000000000000000000000000000000000')
+            return new PublicKey(null);
         return new PublicKey(Point.decodeFrom(secp256k1, buffer));
     }
 
-    toBuffer(compressed = this.Q.compressed) {
+    toBuffer(compressed = this.Q? this.Q.compressed : null) {
+        if (this.Q === null)
+            return new Buffer('000000000000000000000000000000000000000000000000000000000000000000', 'hex');
         return this.Q.getEncoded(compressed);
     }
 


### PR DESCRIPTION
Null public keys (i.e. GPH1111111111111111111111111111111114T1Anm) would cause an exception when serialized. This update fixes that issue, and now public keys can be serialized/deserialized correctly.

Changes are credited to James Calfee; I'm just submitting the pull request.